### PR TITLE
feat: add policy engine, offline mode, dependency grouping, and auto-merge

### DIFF
--- a/dependapy/application/config.py
+++ b/dependapy/application/config.py
@@ -62,6 +62,13 @@ class AppConfig:
     vcs_base_branch: str = "main"
     branch_prefix: str = "dependapy/"
 
+    # PR Limits
+    max_prs: int = 10
+    notify_codeowners: bool = True
+
+    # Offline Mode — Air-Gapped Runner ohne Internet
+    offline: bool = False
+
     # Logging
     log_level: str = "INFO"
 
@@ -94,6 +101,13 @@ class AppConfig:
             "vcs_token": _env("VCS_TOKEN") or None,
             "vcs_base_branch": _env("VCS_BASE_BRANCH", str(fd.get("vcs_base_branch", "main"))),
             "branch_prefix": _env("BRANCH_PREFIX", str(fd.get("branch_prefix", "dependapy/"))),
+            "max_prs": int(_env("MAX_PRS", str(fd.get("max_prs", 10)))),
+            "notify_codeowners": _env(
+                "NOTIFY_CODEOWNERS", str(fd.get("notify_codeowners", True))
+            ).lower()
+            not in ("false", "0", "no"),
+            "offline": _env("OFFLINE", str(fd.get("offline", False))).lower()
+            not in ("false", "0", "no", ""),
             "log_level": _env("LOG_LEVEL", str(fd.get("log_level", "INFO"))),
             "policy_file": _env("POLICY_FILE", str(fd.get("policy_file", ".dependapy.yml"))),
         }

--- a/dependapy/application/use_cases.py
+++ b/dependapy/application/use_cases.py
@@ -12,7 +12,8 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from dependapy.application.dtos import AnalysisResult, SubmitResult, UpdateResult
-from dependapy.domain.models import Project
+from dependapy.domain.models import Dependency, Project
+from dependapy.domain.policy import Policy
 from dependapy.domain.ports import (
     PackageRegistry,
     ProjectRepository,
@@ -24,6 +25,14 @@ from dependapy.domain.value_objects import Version
 from dependapy.domain.vcs_types import PRRequest
 
 logger = logging.getLogger("dependapy.application")
+
+
+def _update_type_allowed(dep: Dependency, policy: Policy) -> bool:
+    """Prüft ob der Update-Typ einer Dependency durch die Policy erlaubt ist."""
+    ut = dep.update_type()
+    if ut is None:
+        return True
+    return ut.value in policy.allowed_update_types(dep.spec.name)
 
 
 class AnalyzeDependencies:
@@ -45,7 +54,9 @@ class AnalyzeDependencies:
         self._project_repo = project_repo
         self._python_registry = python_registry
 
-    def execute(self, project_path: Path) -> Result[list[AnalysisResult], str]:
+    def execute(
+        self, project_path: Path, *, policy: Policy | None = None
+    ) -> Result[list[AnalysisResult], str]:
         """Führt die Dependency-Analyse durch."""
         match self._project_repo.find_project_files(project_path):
             case Err(error):
@@ -68,8 +79,18 @@ class AnalyzeDependencies:
         for file_path in project_files:
             match self._project_repo.load_project(file_path):
                 case Ok(project):
-                    self._enrich_with_latest_versions(project)
+                    self._enrich_with_latest_versions(project, policy=policy)
                     outdated = project.get_outdated()
+
+                    # Policy-Filter: Ignorierte Packages und unerlaubte Update-Typen
+                    if policy:
+                        outdated = [
+                            d
+                            for d in outdated
+                            if not policy.is_ignored(d.spec.name)
+                            and _update_type_allowed(d, policy)
+                        ]
+
                     project.mark_analyzed()
 
                     # Python EOL-Check: Erfüllt mindestens eine supported
@@ -103,9 +124,16 @@ class AnalyzeDependencies:
 
         return Ok(results)
 
-    def _enrich_with_latest_versions(self, project: Project) -> None:
+    def _enrich_with_latest_versions(
+        self, project: Project, *, policy: Policy | None = None
+    ) -> None:
         """Reichert jede Dependency mit der neuesten Version an."""
-        names = [dep.spec.name for dep in project.dependencies]
+        # Ignorierte Packages nicht abfragen — spart HTTP-Calls
+        names = [
+            dep.spec.name
+            for dep in project.dependencies
+            if not (policy and policy.is_ignored(dep.spec.name))
+        ]
         batch_results = self._registry.get_latest_versions_batch(names)
 
         for i, dep in enumerate(project.dependencies):
@@ -154,7 +182,13 @@ class ApplyUpdates:
 
 
 class SubmitChanges:
-    """Use Case: Reicht Änderungen via VCS ein (PR oder Patch)."""
+    """Use Case: Reicht Änderungen via VCS ein (PR oder Patch).
+
+    Unterstützt:
+    - Einzelner Sammel-PR (Legacy)
+    - Per-Projekt PRs mit max_prs Limit
+    - CODEOWNERS-basierte Reviewer-Zuweisung
+    """
 
     def __init__(self, vcs: VCSPort) -> None:
         self._vcs = vcs
@@ -166,6 +200,8 @@ class SubmitChanges:
         *,
         branch_name: str = "dependapy/dependency-updates",
         base_branch: str = "main",
+        reviewers: list[str] | None = None,
+        policy: Policy | None = None,
     ) -> Result[SubmitResult, str]:
         """Erstellt Branch, Commit, Push und PR."""
         # 1. Branch erstellen
@@ -175,8 +211,13 @@ class SubmitChanges:
             case Ok(_):
                 pass
 
-        # 2. Commit
-        commit_msg = "chore(dependapy): update dependencies and python version"
+        # 2. Commit — Message aus Policy oder Default
+        if policy:
+            commit_msg = policy.format_commit_message(
+                "dependapy", "update dependencies and python version"
+            )
+        else:
+            commit_msg = "chore(dependapy): update dependencies and python version"
         match self._vcs.commit_changes(repo_path, updated_files, commit_msg):
             case Err(error):
                 return Err(f"Commit fehlgeschlagen: {error}")
@@ -190,7 +231,11 @@ class SubmitChanges:
             case Ok(_):
                 pass
 
-        # 4. PR erstellen
+        # 4. PR erstellen — Merge Policy Reviewers + CODEOWNERS Reviewers
+        merged_reviewers = self._merge_reviewers(reviewers, policy)
+        labels = list(policy.labels) if policy and policy.labels else None
+        auto_merge = policy.auto_merge if policy else False
+
         match self._vcs.get_repo_info(repo_path):
             case Err(error):
                 return Err(f"Repo-Info nicht abrufbar: {error}")
@@ -205,6 +250,9 @@ class SubmitChanges:
                         "This PR was automatically created by dependapy.\n\n"
                         "It updates dependencies to their latest versions."
                     ),
+                    reviewers=merged_reviewers,
+                    labels=labels,
+                    auto_merge=auto_merge,
                 )
                 match self._vcs.create_pull_request(pr_request):
                     case Ok(pr_result):
@@ -218,3 +266,246 @@ class SubmitChanges:
                         )
                     case Err(pr_error):
                         return Err(f"PR-Erstellung fehlgeschlagen: {pr_error}")
+
+    @staticmethod
+    def _merge_reviewers(
+        codeowner_reviewers: list[str] | None, policy: Policy | None
+    ) -> list[str] | None:
+        """Kombiniert CODEOWNERS-Reviewer mit Policy-Reviewern."""
+        merged: set[str] = set()
+        if codeowner_reviewers:
+            merged.update(codeowner_reviewers)
+        if policy and policy.reviewers:
+            merged.update(policy.reviewers)
+        return sorted(merged) if merged else None
+
+    def execute_per_project(
+        self,
+        repo_path: Path,
+        analysis_results: list[AnalysisResult],
+        updated_files_by_project: dict[Path, list[Path]],
+        *,
+        base_branch: str = "main",
+        branch_prefix: str = "dependapy/",
+        max_prs: int = 10,
+        reviewers_by_file: dict[str, list[str]] | None = None,
+        policy: Policy | None = None,
+    ) -> list[Result[SubmitResult, str]]:
+        """Erstellt separate PRs per Projekt oder Gruppe mit max_prs Limit.
+
+        Wenn die Policy Gruppen definiert, werden Dependencies aus
+        verschiedenen Projekten in einem gemeinsamen PR zusammengefasst.
+        Ungrouped Dependencies erhalten weiterhin per-Projekt PRs.
+
+        Args:
+            repo_path: Root des Repositories.
+            analysis_results: Analyse-Ergebnisse pro Projekt.
+            updated_files_by_project: Mapping Projekt-Pfad → aktualisierte Dateien.
+            base_branch: Basis-Branch für PRs.
+            branch_prefix: Prefix für Branch-Namen.
+            max_prs: Maximale Anzahl PRs (default: 10).
+            reviewers_by_file: Mapping Dateipfad → Reviewer-Liste (aus CODEOWNERS).
+            policy: Optionale Policy mit Gruppendefinitionen.
+
+        Returns:
+            Liste von Results (ein Eintrag pro erstelltem PR).
+        """
+        # Gruppierte PRs wenn Policy Gruppen definiert
+        if policy and policy.groups:
+            return self._execute_grouped(
+                repo_path=repo_path,
+                analysis_results=analysis_results,
+                updated_files_by_project=updated_files_by_project,
+                base_branch=base_branch,
+                branch_prefix=branch_prefix,
+                max_prs=max_prs,
+                reviewers_by_file=reviewers_by_file,
+                policy=policy,
+            )
+
+        return self._execute_per_project_simple(
+            repo_path=repo_path,
+            analysis_results=analysis_results,
+            updated_files_by_project=updated_files_by_project,
+            base_branch=base_branch,
+            branch_prefix=branch_prefix,
+            max_prs=max_prs,
+            reviewers_by_file=reviewers_by_file,
+            policy=policy,
+        )
+
+    def _execute_grouped(
+        self,
+        repo_path: Path,
+        analysis_results: list[AnalysisResult],
+        updated_files_by_project: dict[Path, list[Path]],
+        *,
+        base_branch: str,
+        branch_prefix: str,
+        max_prs: int,
+        reviewers_by_file: dict[str, list[str]] | None,
+        policy: Policy,
+    ) -> list[Result[SubmitResult, str]]:
+        """Erstellt PRs nach Dependency-Gruppen aus der Policy.
+
+        Sammelt alle aktualisierten Dateien, deren Projekte Dependencies
+        in derselben Gruppe haben. Projekte ohne Gruppen-Match bekommen
+        weiterhin individuelle PRs.
+        """
+        # 1. Sammle alle Dateien pro Gruppe + ungrouped
+        group_files: dict[str, set[Path]] = {}
+        ungrouped_projects: list[AnalysisResult] = []
+
+        for analysis in analysis_results:
+            if analysis.outdated_count == 0:
+                continue
+
+            project_files = updated_files_by_project.get(analysis.project.path, [])
+            if not project_files:
+                continue
+
+            # Prüfe ob irgendeine outdated dep zu einer Gruppe gehört
+            matched_groups: set[str] = set()
+            for dep in analysis.project.get_outdated():
+                group = policy.find_group(dep.spec.name)
+                if group:
+                    matched_groups.add(group.name)
+
+            if matched_groups:
+                for group_name in matched_groups:
+                    group_files.setdefault(group_name, set()).update(project_files)
+            else:
+                ungrouped_projects.append(analysis)
+
+        # 2. PRs erstellen: erst Gruppen, dann ungrouped
+        results: list[Result[SubmitResult, str]] = []
+        pr_count = 0
+
+        for group_name, files in sorted(group_files.items()):
+            if pr_count >= max_prs:
+                logger.warning("Max PRs erreicht (%d). Überspringe Gruppe: %s", max_prs, group_name)
+                break
+
+            reviewers = self._collect_reviewers(list(files), repo_path, reviewers_by_file)
+            branch_name = f"{branch_prefix}group-{group_name.lower()}"
+
+            result = self.execute(
+                repo_path=repo_path,
+                updated_files=list(files),
+                branch_name=branch_name,
+                base_branch=base_branch,
+                reviewers=reviewers,
+                policy=policy,
+            )
+            results.append(result)
+
+            match result:
+                case Ok(_):
+                    pr_count += 1
+                    logger.info("Gruppen-PR erstellt für: %s", group_name)
+                case Err(error):
+                    logger.error("Gruppen-PR für %s fehlgeschlagen: %s", group_name, error)
+
+        # 3. Ungrouped als per-Projekt PRs
+        ungrouped_files = {
+            a.project.path: updated_files_by_project.get(a.project.path, [])
+            for a in ungrouped_projects
+        }
+        if ungrouped_files:
+            remaining = self._execute_per_project_simple(
+                repo_path=repo_path,
+                analysis_results=ungrouped_projects,
+                updated_files_by_project=ungrouped_files,
+                base_branch=base_branch,
+                branch_prefix=branch_prefix,
+                max_prs=max_prs - pr_count,
+                reviewers_by_file=reviewers_by_file,
+                policy=policy,
+            )
+            results.extend(remaining)
+
+        logger.info("PRs erstellt: %d (max: %d)", pr_count, max_prs)
+        return results
+
+    @staticmethod
+    def _collect_reviewers(
+        files: list[Path],
+        repo_path: Path,
+        reviewers_by_file: dict[str, list[str]] | None,
+    ) -> list[str] | None:
+        """Sammelt Reviewer aus CODEOWNERS für eine Liste von Dateien."""
+        if not reviewers_by_file:
+            return None
+        all_reviewers: set[str] = set()
+        for f in files:
+            rel_path = str(f.relative_to(repo_path))
+            all_reviewers.update(reviewers_by_file.get(rel_path, []))
+        return sorted(all_reviewers) if all_reviewers else None
+
+    def _execute_per_project_simple(
+        self,
+        repo_path: Path,
+        analysis_results: list[AnalysisResult],
+        updated_files_by_project: dict[Path, list[Path]],
+        *,
+        base_branch: str = "main",
+        branch_prefix: str = "dependapy/",
+        max_prs: int = 10,
+        reviewers_by_file: dict[str, list[str]] | None = None,
+        policy: Policy | None = None,
+    ) -> list[Result[SubmitResult, str]]:
+        results: list[Result[SubmitResult, str]] = []
+        pr_count = 0
+
+        for analysis in analysis_results:
+            if pr_count >= max_prs:
+                logger.warning(
+                    "Max PRs erreicht (%d). Überspringe: %s",
+                    max_prs,
+                    analysis.project.name,
+                )
+                break
+
+            if analysis.outdated_count == 0:
+                continue
+
+            project_files = updated_files_by_project.get(analysis.project.path, [])
+            if not project_files:
+                continue
+
+            # Reviewer für die Dateien dieses Projekts ermitteln
+            reviewers: list[str] | None = None
+            if reviewers_by_file:
+                all_reviewers: set[str] = set()
+                for f in project_files:
+                    rel_path = str(f.relative_to(repo_path))
+                    all_reviewers.update(reviewers_by_file.get(rel_path, []))
+                if all_reviewers:
+                    reviewers = sorted(all_reviewers)
+
+            # Branch-Name pro Projekt
+            safe_name = analysis.project.name.replace("/", "-").replace(" ", "-").lower()
+            branch_name = f"{branch_prefix}update-{safe_name}"
+
+            result = self.execute(
+                repo_path=repo_path,
+                updated_files=project_files,
+                branch_name=branch_name,
+                base_branch=base_branch,
+                reviewers=reviewers,
+                policy=policy,
+            )
+            results.append(result)
+
+            match result:
+                case Ok(_):
+                    pr_count += 1
+                case Err(error):
+                    logger.error(
+                        "PR für %s fehlgeschlagen: %s",
+                        analysis.project.name,
+                        error,
+                    )
+
+        logger.info("PRs erstellt: %d/%d (max: %d)", pr_count, len(analysis_results), max_prs)
+        return results

--- a/dependapy/bootstrap.py
+++ b/dependapy/bootstrap.py
@@ -22,6 +22,7 @@ from dependapy.domain.ports import (
 )
 from dependapy.infrastructure.adapters.endoflife import EndOfLifeAdapter
 from dependapy.infrastructure.adapters.filesystem import FileSystemProjectRepository
+from dependapy.infrastructure.adapters.offline_registry import OfflineRegistryAdapter
 from dependapy.infrastructure.adapters.pypi import PyPIAdapter
 from dependapy.infrastructure.http import HttpClient
 from dependapy.infrastructure.vcs.git_client import GitClient
@@ -77,19 +78,34 @@ def bootstrap(config: AppConfig | None = None) -> Application:
     if config is None:
         config = AppConfig.from_env()
 
-    # HTTP Client
-    http = HttpClient(timeout=config.api_timeout, max_retries=3)
+    closables: list[Closable] = []
+
+    if config.offline:
+        # Offline Mode: Keine HTTP-Verbindungen, lokale Versionsquellen
+        from pathlib import Path
+
+        logger.info("Offline-Modus aktiv — verwende lokale Versionsquellen")
+        registry: PackageRegistry = OfflineRegistryAdapter(Path.cwd())
+        python_reg: PythonVersionRegistry = EndOfLifeAdapter(
+            http_client=HttpClient(timeout=1, max_retries=0),
+            api_url=config.python_eol_api_url,
+            num_versions=config.num_latest_python_versions,
+        )
+    else:
+        # Online Mode: HTTP-Client mit Retry
+        http = HttpClient(timeout=config.api_timeout, max_retries=3)
+        registry = PyPIAdapter(
+            http_client=http,
+            base_url=config.pypi_base_url,
+        )
+        python_reg = EndOfLifeAdapter(
+            http_client=http,
+            api_url=config.python_eol_api_url,
+            num_versions=config.num_latest_python_versions,
+        )
+        closables.extend([registry, http])  # type: ignore[list-item]
 
     # Adapters
-    registry: PackageRegistry = PyPIAdapter(
-        http_client=http,
-        base_url=config.pypi_base_url,
-    )
-    python_reg: PythonVersionRegistry = EndOfLifeAdapter(
-        http_client=http,
-        api_url=config.python_eol_api_url,
-        num_versions=config.num_latest_python_versions,
-    )
     project_repo: ProjectRepository = FileSystemProjectRepository()
     vcs: VCSPort = _create_vcs(config)
 
@@ -103,7 +119,7 @@ def bootstrap(config: AppConfig | None = None) -> Application:
         apply=ApplyUpdates(project_repo=project_repo),
         submit=SubmitChanges(vcs=vcs),
         config=config,
-        _closables=[registry, http],
+        _closables=closables,
     )
 
 

--- a/dependapy/domain/__init__.py
+++ b/dependapy/domain/__init__.py
@@ -20,6 +20,13 @@ from dependapy.domain.errors import (
     VCSError,
 )
 from dependapy.domain.models import Dependency, PlannedUpdate, PlanStatus, Project, UpdatePlan
+from dependapy.domain.policy import (
+    AllowRule,
+    CommitMessage,
+    DependencyGroup,
+    IgnoreRule,
+    Policy,
+)
 from dependapy.domain.result import Err, Ok, Result, collect_results
 from dependapy.domain.services import (
     compute_update_type,
@@ -36,12 +43,16 @@ from dependapy.domain.value_objects import (
 from dependapy.domain.vcs_types import PRRequest, PRResult, RepoInfo
 
 __all__ = [
+    "AllowRule",
     "BranchExistsError",
+    "CommitMessage",
     "ConfigurationError",
     "ConstraintOperator",
     "Dependency",
+    "DependencyGroup",
     "DomainError",
     "Err",
+    "IgnoreRule",
     "Ok",
     "PRCreationError",
     "PRRequest",
@@ -50,6 +61,7 @@ __all__ = [
     "PackageSpec",
     "PlanStatus",
     "PlannedUpdate",
+    "Policy",
     "PolicyError",
     "PolicyNotFoundError",
     "PolicyValidationError",

--- a/dependapy/domain/policy.py
+++ b/dependapy/domain/policy.py
@@ -1,0 +1,117 @@
+"""
+Policy — Domain Model für .dependapy.yml Konfiguration.
+
+Definiert Regeln für Dependency-Updates:
+- ignore: Packages die nicht aktualisiert werden
+- allow: Erlaubte Update-Typen pro Package
+- labels: PR-Labels
+- reviewers / assignees: PR-Reviewer und -Zuweisungen
+- commit_message: Commit-Message-Template mit Prefix
+- groups: Gruppenweise Updates in einem PR
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from fnmatch import fnmatch
+
+
+@dataclass(frozen=True, slots=True)
+class IgnoreRule:
+    """Ignoriert ein Package bei Updates.
+
+    name kann ein glob-Pattern sein (z.B. 'boto*').
+    versions kann ein Bereich sein (z.B. '>= 2.0').
+    """
+
+    name: str
+    versions: str | None = None
+    reason: str | None = None
+
+    def matches(self, package_name: str) -> bool:
+        """Prüft ob der Package-Name zu dieser Ignore-Regel passt."""
+        return fnmatch(package_name.lower(), self.name.lower())
+
+
+@dataclass(frozen=True, slots=True)
+class AllowRule:
+    """Erlaubte Update-Typen für ein Package oder Glob-Pattern.
+
+    update_types: "major", "minor", "patch" — welche Updates erlaubt sind.
+    """
+
+    name: str
+    update_types: frozenset[str] = frozenset({"major", "minor", "patch"})
+
+    def matches(self, package_name: str) -> bool:
+        """Prüft ob der Package-Name zu dieser Allow-Regel passt."""
+        return fnmatch(package_name.lower(), self.name.lower())
+
+
+@dataclass(frozen=True, slots=True)
+class CommitMessage:
+    """Commit-Message-Template für PRs."""
+
+    prefix: str = "chore(deps)"
+    include_scope: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyGroup:
+    """Gruppiert Packages in einen gemeinsamen PR.
+
+    patterns: Glob-Patterns für Package-Namen.
+    """
+
+    name: str
+    patterns: tuple[str, ...] = ()
+
+    def matches(self, package_name: str) -> bool:
+        """Prüft ob das Package zu dieser Gruppe gehört."""
+        return any(fnmatch(package_name.lower(), p.lower()) for p in self.patterns)
+
+
+@dataclass(frozen=True, slots=True)
+class Policy:
+    """Zentrale Policy-Definition aus .dependapy.yml.
+
+    Wird vom PolicyLoader geladen und von Use Cases konsumiert.
+    """
+
+    version: int = 1
+    ignore: tuple[IgnoreRule, ...] = ()
+    allow: tuple[AllowRule, ...] = ()
+    labels: tuple[str, ...] = ()
+    reviewers: tuple[str, ...] = ()
+    assignees: tuple[str, ...] = ()
+    commit_message: CommitMessage = field(default_factory=CommitMessage)
+    groups: tuple[DependencyGroup, ...] = ()
+    auto_merge: bool = False
+
+    def is_ignored(self, package_name: str) -> bool:
+        """Prüft ob ein Package ignoriert werden soll."""
+        return any(rule.matches(package_name) for rule in self.ignore)
+
+    def allowed_update_types(self, package_name: str) -> frozenset[str]:
+        """Gibt die erlaubten Update-Typen für ein Package zurück.
+
+        Wenn keine Allow-Regel greift, sind alle Updates erlaubt.
+        """
+        for rule in self.allow:
+            if rule.matches(package_name):
+                return rule.update_types
+        return frozenset({"major", "minor", "patch"})
+
+    def find_group(self, package_name: str) -> DependencyGroup | None:
+        """Findet die Gruppe, zu der ein Package gehört."""
+        for group in self.groups:
+            if group.matches(package_name):
+                return group
+        return None
+
+    def format_commit_message(self, scope: str, description: str) -> str:
+        """Formatiert eine Commit-Message nach Template."""
+        prefix = self.commit_message.prefix
+        if self.commit_message.include_scope and scope:
+            return f"{prefix}({scope}): {description}"
+        return f"{prefix}: {description}"

--- a/dependapy/domain/vcs_types.py
+++ b/dependapy/domain/vcs_types.py
@@ -21,6 +21,9 @@ class PRRequest:
     base_branch: str
     title: str
     body: str
+    reviewers: list[str] | None = None
+    labels: list[str] | None = None
+    auto_merge: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/dependapy/infrastructure/adapters/codeowners.py
+++ b/dependapy/infrastructure/adapters/codeowners.py
@@ -1,0 +1,108 @@
+"""
+CODEOWNERS Parser — Liest und matcht CODEOWNERS-Dateien.
+
+Unterstützt GitHub CODEOWNERS Format (.github/CODEOWNERS, CODEOWNERS, docs/CODEOWNERS).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+from pathlib import Path
+
+logger = logging.getLogger("dependapy.infrastructure.adapters.codeowners")
+
+# Standard-Pfade für CODEOWNERS
+_CODEOWNERS_PATHS = (
+    ".github/CODEOWNERS",
+    "CODEOWNERS",
+    "docs/CODEOWNERS",
+)
+
+
+class CodeownersEntry:
+    """Eine Regel aus der CODEOWNERS-Datei."""
+
+    __slots__ = ("owners", "pattern")
+
+    def __init__(self, pattern: str, owners: list[str]) -> None:
+        self.pattern = pattern
+        self.owners = owners
+
+    def matches(self, file_path: str) -> bool:
+        """Prüft ob ein Dateipfad zu dieser Regel passt."""
+        # Normalize: entferne führende /
+        pattern = self.pattern.lstrip("/")
+        normalized = file_path.lstrip("/")
+
+        # Exakter Verzeichnis-Match: "src/" matcht alles unter src/
+        if pattern.endswith("/"):
+            return normalized.startswith(pattern) or fnmatch.fnmatch(normalized, f"{pattern}**")
+
+        # Glob-Pattern: "*.py", "src/**/*.toml"
+        if fnmatch.fnmatch(normalized, pattern):
+            return True
+
+        # Auch als Verzeichnis-Prefix matchen: "src" matcht "src/foo.py"
+        if not any(c in pattern for c in ("*", "?", "[")):
+            return normalized.startswith(f"{pattern}/")
+
+        return False
+
+
+def parse_codeowners(repo_root: Path) -> list[CodeownersEntry]:
+    """Parst die CODEOWNERS-Datei eines Repositories.
+
+    Sucht in den Standard-Pfaden (.github/CODEOWNERS, CODEOWNERS, docs/CODEOWNERS).
+    Gibt eine leere Liste zurück wenn keine Datei gefunden wird.
+    """
+    for relative_path in _CODEOWNERS_PATHS:
+        codeowners_path = repo_root / relative_path
+        if codeowners_path.is_file():
+            logger.debug("CODEOWNERS gefunden: %s", codeowners_path)
+            return _parse_file(codeowners_path)
+
+    logger.debug("Keine CODEOWNERS-Datei gefunden in %s", repo_root)
+    return []
+
+
+def _parse_file(path: Path) -> list[CodeownersEntry]:
+    """Parst eine einzelne CODEOWNERS-Datei."""
+    entries: list[CodeownersEntry] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+
+        pattern = parts[0]
+        owners = [p for p in parts[1:] if not p.startswith("#")]
+        if owners:
+            entries.append(CodeownersEntry(pattern=pattern, owners=owners))
+
+    logger.debug("CODEOWNERS: %d Regeln geladen", len(entries))
+    return entries
+
+
+def find_owners_for_file(file_path: str, entries: list[CodeownersEntry]) -> list[str]:
+    """Findet die CODEOWNERS für eine Datei.
+
+    CODEOWNERS-Regeln werden von unten nach oben ausgewertet —
+    die letzte passende Regel gewinnt (wie bei GitHub).
+    """
+    owners: list[str] = []
+    for entry in entries:
+        if entry.matches(file_path):
+            owners = entry.owners  # Letzte passende Regel überschreibt
+    return owners
+
+
+def find_owners_for_files(file_paths: list[str], entries: list[CodeownersEntry]) -> list[str]:
+    """Findet alle eindeutigen CODEOWNERS für eine Liste von Dateien."""
+    all_owners: set[str] = set()
+    for file_path in file_paths:
+        all_owners.update(find_owners_for_file(file_path, entries))
+    return sorted(all_owners)

--- a/dependapy/infrastructure/adapters/offline_registry.py
+++ b/dependapy/infrastructure/adapters/offline_registry.py
@@ -1,0 +1,117 @@
+"""
+Offline Version Source — Lokale Versionsquelle für Air-Gapped Runner.
+
+Liest Package-Versionen aus lokalen Quellen statt von PyPI:
+1. uv.lock (TOML-Format)
+2. requirements.txt (pinned versions)
+
+Implementiert das PackageRegistry Protocol für den Offline-Betrieb.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import tomllib
+from pathlib import Path
+
+from dependapy.domain.errors import PackageNotFoundError, RegistryError
+from dependapy.domain.result import Err, Ok, Result
+from dependapy.domain.value_objects import Version
+
+logger = logging.getLogger("dependapy.infrastructure.adapters.offline_registry")
+
+# Package name normalization: PEP 503
+_NORMALIZE_RE = re.compile(r"[-_.]+")
+
+
+def _normalize(name: str) -> str:
+    """PEP 503 — normalisiert Package-Namen für Vergleiche."""
+    return _NORMALIZE_RE.sub("-", name).lower()
+
+
+class OfflineRegistryAdapter:
+    """Offline Package Registry — liest Versionen aus lokalen Lock-Dateien.
+
+    Durchsucht das Projektverzeichnis nach uv.lock oder requirements.txt
+    und baut einen lokalen Versions-Cache auf.
+    """
+
+    def __init__(self, project_root: Path) -> None:
+        self._versions: dict[str, Version] = {}
+        self._loaded = False
+        self._project_root = project_root
+
+    def _ensure_loaded(self) -> None:
+        """Lazy-Load: Lädt Versionen erst beim ersten Zugriff."""
+        if self._loaded:
+            return
+        self._loaded = True
+
+        # Priorität: uv.lock > requirements.txt
+        uv_lock = self._project_root / "uv.lock"
+        if uv_lock.is_file():
+            self._load_uv_lock(uv_lock)
+            return
+
+        # Fallback: requirements.txt / requirements-*.txt
+        for req_file in sorted(self._project_root.glob("requirements*.txt")):
+            self._load_requirements_txt(req_file)
+
+    def _load_uv_lock(self, path: Path) -> None:
+        """Parst uv.lock (TOML-Format) und extrahiert Package-Versionen."""
+        try:
+            data = tomllib.loads(path.read_text(encoding="utf-8"))
+            packages = data.get("package", [])
+            for pkg in packages:
+                name = pkg.get("name", "")
+                version = pkg.get("version", "")
+                if name and version:
+                    try:
+                        self._versions[_normalize(name)] = Version.from_string(version)
+                    except (ValueError, TypeError):
+                        logger.debug("Ungültige Version in uv.lock: %s=%s", name, version)
+            logger.info("Offline-Registry: %d Packages aus %s geladen", len(self._versions), path)
+        except (tomllib.TOMLDecodeError, OSError) as e:
+            logger.warning("uv.lock nicht lesbar: %s", e)
+
+    def _load_requirements_txt(self, path: Path) -> None:
+        """Parst requirements.txt und extrahiert pinned Versionen."""
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line or line.startswith("#") or line.startswith("-"):
+                    continue
+                # Format: package==1.2.3 oder package>=1.2.3
+                match = re.match(r"^([a-zA-Z0-9_.-]+)==([^\s;#]+)", line)
+                if match:
+                    name, version = match.group(1), match.group(2)
+                    try:
+                        self._versions[_normalize(name)] = Version.from_string(version)
+                    except (ValueError, TypeError):
+                        pass
+            logger.info("Offline-Registry: %d Packages aus %s geladen", len(self._versions), path)
+        except OSError as e:
+            logger.warning("requirements.txt nicht lesbar: %s", e)
+
+    def close(self) -> None:
+        """Kompatibilität mit Closable-Protocol."""
+
+    def get_latest_version(self, package_name: str) -> Result[Version, RegistryError]:
+        """Gibt die lokal bekannte Version eines Packages zurück."""
+        self._ensure_loaded()
+        normalized = _normalize(package_name)
+        if normalized in self._versions:
+            return Ok(self._versions[normalized])
+        return Err(
+            PackageNotFoundError(
+                f"Package '{package_name}' nicht in lokaler Versionsquelle gefunden"
+            )
+        )
+
+    def get_latest_versions_batch(
+        self, package_names: list[str]
+    ) -> dict[str, Result[Version, RegistryError]]:
+        """Gibt Versionen für mehrere Packages zurück (synchron, kein Netzwerk)."""
+        self._ensure_loaded()
+        return {name: self.get_latest_version(name) for name in package_names}

--- a/dependapy/infrastructure/adapters/policy_loader.py
+++ b/dependapy/infrastructure/adapters/policy_loader.py
@@ -1,15 +1,181 @@
 """
-YAML Policy Loader — Stub für Phase 2.
+YAML Policy Loader — Lädt und validiert .dependapy.yml Dateien.
 
-Wird .dependapy.yml Policy-Dateien laden und validieren.
+Unterstütztes Format:
+
+    version: 1
+    ignore:
+      - name: "boto*"
+        reason: "managed by infra team"
+      - name: "legacy-pkg"
+    allow:
+      - name: "*"
+        update-types: ["minor", "patch"]
+      - name: "requests"
+        update-types: ["major", "minor", "patch"]
+    labels: ["dependencies", "automated"]
+    reviewers: ["@user1", "@org/team"]
+    assignees: ["@user2"]
+    commit-message:
+      prefix: "chore(deps)"
+      include-scope: true
+    groups:
+      - name: "aws"
+        patterns: ["boto*", "aws*"]
 """
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
+from typing import Any
 
-# Phase 2: Policy Engine
-# - Erlaubte Update-Typen pro Package
-# - Package Pinning
-# - Auto-Merge Regeln
-# - Ignore-Listen
-# - Custom Python-Version-Policies
+from dependapy.domain.errors import PolicyError, PolicyNotFoundError, PolicyValidationError
+from dependapy.domain.policy import (
+    AllowRule,
+    CommitMessage,
+    DependencyGroup,
+    IgnoreRule,
+    Policy,
+)
+from dependapy.domain.result import Err, Ok, Result
+
+logger = logging.getLogger("dependapy.infrastructure.adapters.policy_loader")
+
+
+def load_policy(project_root: Path) -> Result[Policy, PolicyError]:
+    """Lädt eine .dependapy.yml Policy-Datei aus dem Projekt-Root.
+
+    Returns:
+        Ok(Policy) wenn die Datei existiert und valide ist.
+        Err(PolicyNotFoundError) wenn keine Policy-Datei gefunden wird.
+        Err(PolicyValidationError) wenn die Datei ungültig ist.
+    """
+    candidates = [
+        project_root / ".dependapy.yml",
+        project_root / ".dependapy.yaml",
+        project_root / "dependapy.yml",
+        project_root / "dependapy.yaml",
+    ]
+
+    policy_path: Path | None = None
+    for candidate in candidates:
+        if candidate.is_file():
+            policy_path = candidate
+            break
+
+    if policy_path is None:
+        return Err(PolicyNotFoundError("Keine .dependapy.yml gefunden"))
+
+    logger.info("Policy geladen: %s", policy_path)
+
+    try:
+        import yaml
+    except ImportError:
+        # PyYAML nicht installiert — parse manuell nicht möglich
+        # Fallback: versuche tomllib falls es eine TOML-Section ist
+        return Err(
+            PolicyValidationError(
+                "PyYAML ist nicht installiert. "
+                "Installiere mit: pip install dependapy[policy] oder pip install pyyaml"
+            )
+        )
+
+    try:
+        raw = policy_path.read_text(encoding="utf-8")
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as e:
+        return Err(PolicyValidationError(f"YAML-Syntax-Fehler in {policy_path}: {e}"))
+
+    if not isinstance(data, dict):
+        return Err(PolicyValidationError("Policy-Datei muss ein YAML-Dictionary sein"))
+
+    return _parse_policy(data)
+
+
+def _parse_policy(
+    data: dict[str, Any],
+) -> Result[Policy, PolicyError]:
+    """Parst ein YAML-Dictionary in ein Policy-Objekt."""
+    try:
+        version = int(data.get("version", 1))
+        if version != 1:
+            return Err(PolicyValidationError(f"Unbekannte Policy-Version: {version}"))
+
+        ignore = _parse_ignore(data.get("ignore", []))
+        allow = _parse_allow(data.get("allow", []))
+        labels = tuple(str(l) for l in data.get("labels", []))  # noqa: E741
+        reviewers = tuple(str(r) for r in data.get("reviewers", []))
+        assignees = tuple(str(a) for a in data.get("assignees", []))
+        commit_message = _parse_commit_message(data.get("commit-message", {}))
+        groups = _parse_groups(data.get("groups", []))
+        auto_merge = bool(data.get("auto-merge", False))
+
+        return Ok(
+            Policy(
+                version=version,
+                ignore=ignore,
+                allow=allow,
+                labels=labels,
+                reviewers=reviewers,
+                assignees=assignees,
+                commit_message=commit_message,
+                groups=groups,
+                auto_merge=auto_merge,
+            )
+        )
+    except (TypeError, ValueError, KeyError) as e:
+        return Err(PolicyValidationError(f"Policy-Validierungsfehler: {e}"))
+
+
+def _parse_ignore(raw: list[Any]) -> tuple[IgnoreRule, ...]:
+    """Parst die ignore-Section."""
+    rules: list[IgnoreRule] = []
+    for item in raw:
+        if isinstance(item, str):
+            rules.append(IgnoreRule(name=item))
+        elif isinstance(item, dict):
+            rules.append(
+                IgnoreRule(
+                    name=str(item["name"]),
+                    versions=item.get("versions"),
+                    reason=item.get("reason"),
+                )
+            )
+    return tuple(rules)
+
+
+def _parse_allow(raw: list[Any]) -> tuple[AllowRule, ...]:
+    """Parst die allow-Section."""
+    rules: list[AllowRule] = []
+    for item in raw:
+        if isinstance(item, dict):
+            name = str(item["name"])
+            raw_types = item.get("update-types", ["major", "minor", "patch"])
+            update_types = frozenset(str(t) for t in raw_types)
+            rules.append(AllowRule(name=name, update_types=update_types))
+    return tuple(rules)
+
+
+def _parse_commit_message(raw: dict[str, Any] | None) -> CommitMessage:
+    """Parst die commit-message-Section."""
+    if not raw:
+        return CommitMessage()
+    return CommitMessage(
+        prefix=str(raw.get("prefix", "chore(deps)")),
+        include_scope=bool(raw.get("include-scope", True)),
+    )
+
+
+def _parse_groups(raw: list[Any]) -> tuple[DependencyGroup, ...]:
+    """Parst die groups-Section."""
+    groups: list[DependencyGroup] = []
+    for item in raw:
+        if isinstance(item, dict):
+            groups.append(
+                DependencyGroup(
+                    name=str(item["name"]),
+                    patterns=tuple(str(p) for p in item.get("patterns", [])),
+                )
+            )
+    return tuple(groups)

--- a/dependapy/infrastructure/vcs/github.py
+++ b/dependapy/infrastructure/vcs/github.py
@@ -52,7 +52,7 @@ class GitHubVCSAdapter:
     def create_pull_request(self, request: PRRequest) -> Result[PRResult, VCSError]:
         """Erstellt einen Pull Request via GitHub API (PyGithub)."""
         try:
-            from github import Github  # type: ignore[attr-defined]
+            from github import Github, GithubException  # type: ignore[attr-defined]
 
             gh = Github(self._token)
             repo = gh.get_repo(f"{request.repo_owner}/{request.repo_name}")
@@ -62,6 +62,19 @@ class GitHubVCSAdapter:
                 head=request.head_branch,
                 base=request.base_branch,
             )
+
+            # Reviewer zuweisen wenn angegeben
+            if request.reviewers:
+                self._assign_reviewers(pr, request.reviewers)
+
+            # Labels zuweisen wenn angegeben
+            if request.labels:
+                self._assign_labels(pr, request.labels)
+
+            # Auto-Merge aktivieren wenn konfiguriert
+            if request.auto_merge:
+                self._enable_auto_merge(pr)
+
             logger.info("PR erstellt: %s", pr.html_url)
             return Ok(
                 PRResult(
@@ -76,8 +89,45 @@ class GitHubVCSAdapter:
                     "PyGithub ist nicht installiert. Installiere mit: pip install dependapy[github]"
                 )
             )
+        except GithubException as e:
+            return Err(PRCreationError(f"GitHub PR-Erstellung fehlgeschlagen: {e}"))
         except Exception as e:
             return Err(PRCreationError(f"GitHub PR-Erstellung fehlgeschlagen: {e}"))
+
+    @staticmethod
+    def _assign_reviewers(pr: object, reviewers: list[str]) -> None:
+        """Weist Reviewer einem PR zu (Users und Teams)."""
+        users = [r.lstrip("@") for r in reviewers if "/" not in r]
+        # Teams: @org/team-name → nur team-name
+        teams = [r.split("/", 1)[1] for r in reviewers if "/" in r]
+
+        try:
+            if users or teams:
+                pr.create_review_request(reviewers=users or None, team_reviewers=teams or None)  # type: ignore[union-attr]
+                logger.info("Reviewer zugewiesen: %s", reviewers)
+        except Exception as e:
+            # Reviewer-Zuweisung ist nicht kritisch — nur loggen
+            logger.warning("Reviewer konnten nicht zugewiesen werden: %s", e)
+
+    @staticmethod
+    def _assign_labels(pr: object, labels: list[str]) -> None:
+        """Weist Labels einem PR zu."""
+        try:
+            pr.set_labels(*labels)  # type: ignore[union-attr]
+            logger.info("Labels zugewiesen: %s", labels)
+        except Exception as e:
+            # Label-Zuweisung ist nicht kritisch — nur loggen
+            logger.warning("Labels konnten nicht zugewiesen werden: %s", e)
+
+    @staticmethod
+    def _enable_auto_merge(pr: object) -> None:
+        """Aktiviert Auto-Merge auf dem PR (squash-merge)."""
+        try:
+            pr.enable_automerge(merge_method="SQUASH")  # type: ignore[union-attr]
+            logger.info("Auto-Merge aktiviert für PR #%s", getattr(pr, "number", "?"))
+        except Exception as e:
+            # Auto-Merge braucht Branch-Protection-Rules — nur loggen
+            logger.warning("Auto-Merge konnte nicht aktiviert werden: %s", e)
 
     def get_repo_info(self, repo_path: Path) -> Result[RepoInfo, VCSError]:
         """Extrahiert Repository-Info aus der Git Remote URL."""

--- a/dependapy/presentation/cli.py
+++ b/dependapy/presentation/cli.py
@@ -15,6 +15,12 @@ from pathlib import Path
 from dependapy.application import Err, Ok
 from dependapy.application.config import AppConfig
 from dependapy.bootstrap import Application, bootstrap
+from dependapy.domain.policy import Policy
+from dependapy.infrastructure.adapters.codeowners import (
+    find_owners_for_file,
+    parse_codeowners,
+)
+from dependapy.infrastructure.adapters.policy_loader import load_policy
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -61,6 +67,22 @@ def create_parser() -> argparse.ArgumentParser:
         help="Base branch for PRs (default: main)",
     )
     parser.add_argument(
+        "--max-prs",
+        type=int,
+        default=None,
+        help="Maximum number of PRs to create (default: 10)",
+    )
+    parser.add_argument(
+        "--no-codeowners",
+        action="store_true",
+        help="Do not assign CODEOWNERS as reviewers on PRs",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Run fully offline using local version sources (uv.lock, requirements.txt)",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -98,6 +120,15 @@ def cli_main(argv: list[str] | None = None) -> int:
         config_overrides["vcs_token"] = args.token
     if args.base_branch:
         config_overrides["vcs_base_branch"] = args.base_branch
+    if args.max_prs is not None:
+        config_overrides["max_prs"] = args.max_prs
+    if args.no_codeowners:
+        config_overrides["notify_codeowners"] = False
+    if args.offline:
+        config_overrides["offline"] = True
+        # Offline impliziert den Offline-VCS-Provider
+        if "vcs_provider" not in config_overrides:
+            config_overrides["vcs_provider"] = "offline"
 
     try:
         config = AppConfig.from_env(**config_overrides)
@@ -117,8 +148,17 @@ def cli_main(argv: list[str] | None = None) -> int:
 
 def _run(app: Application, project_path: Path, args: argparse.Namespace) -> int:
     """Führt die eigentliche Logik aus (Analyze → Apply → Submit)."""
+    # Policy laden (optional — wenn .dependapy.yml existiert)
+    policy: Policy | None = None
+    match load_policy(project_path):
+        case Ok(loaded_policy):
+            policy = loaded_policy
+            logging.info("Policy geladen aus %s", project_path)
+        case Err(error):
+            logging.debug("Keine Policy geladen: %s", error)
+
     # 1. Analyze
-    match app.analyze.execute(project_path):
+    match app.analyze.execute(project_path, policy=policy):
         case Ok(results):
             total_outdated = sum(r.outdated_count for r in results)
             total_deps = sum(r.total_count for r in results)
@@ -157,14 +197,81 @@ def _run(app: Application, project_path: Path, args: argparse.Namespace) -> int:
         logging.info("Updates angewendet, kein PR erstellt (--no-pr).")
         return 0
 
-    # 3. Submit Changes
-    match app.submit.execute(project_path, updated_files):
-        case Ok(submit_result):
-            logging.info("Änderungen eingereicht: %s", submit_result.url)
+    # 3. Submit Changes (per-project PRs mit CODEOWNERS)
+    # CODEOWNERS laden
+    reviewers_by_file: dict[str, list[str]] | None = None
+    if app.config.notify_codeowners:
+        codeowners_entries = parse_codeowners(project_path)
+        if codeowners_entries:
+            reviewers_by_file = {}
+            for f in updated_files:
+                rel = str(f.relative_to(project_path))
+                owners = find_owners_for_file(rel, codeowners_entries)
+                if owners:
+                    reviewers_by_file[rel] = owners
+                    logging.debug("CODEOWNERS für %s: %s", rel, owners)
+
+    # Mapping: Projekt-Pfad → Dateien
+    updated_files_by_project: dict[Path, list[Path]] = {}
+    for r in results:
+        if r.outdated_count > 0 and r.project.path in [Path(f) for f in updated_files]:
+            updated_files_by_project[r.project.path] = [r.project.path]
+        elif r.outdated_count > 0:
+            # Match project path to updated files
+            for f in updated_files:
+                if f == r.project.path:
+                    updated_files_by_project.setdefault(r.project.path, []).append(f)
+
+    # Falls nur ein Projekt, nutze den einfachen Sammel-PR
+    if len(updated_files_by_project) <= 1:
+        # Reviewer aus CODEOWNERS sammeln
+        all_reviewers: list[str] | None = None
+        if reviewers_by_file:
+            owners_set: set[str] = set()
+            for owners in reviewers_by_file.values():
+                owners_set.update(owners)
+            if owners_set:
+                all_reviewers = sorted(owners_set)
+
+        match app.submit.execute(
+            project_path,
+            updated_files,
+            reviewers=all_reviewers,
+            policy=policy,
+        ):
+            case Ok(submit_result):
+                logging.info("Änderungen eingereicht: %s", submit_result.url)
+                return 0
+            case Err(error):
+                logging.error("Einreichung fehlgeschlagen: %s", error)
+                return 1
+    else:
+        # Mehrere Projekte: Per-Projekt PRs mit max_prs Limit
+        pr_results = app.submit.execute_per_project(
+            repo_path=project_path,
+            analysis_results=results,
+            updated_files_by_project=updated_files_by_project,
+            base_branch=app.config.vcs_base_branch,
+            branch_prefix=app.config.branch_prefix,
+            max_prs=app.config.max_prs,
+            reviewers_by_file=reviewers_by_file,
+            policy=policy,
+        )
+
+        success_count = sum(1 for r in pr_results if isinstance(r, Ok))
+        error_count = sum(1 for r in pr_results if isinstance(r, Err))
+
+        if success_count > 0:
+            logging.info(
+                "PRs erstellt: %d erfolgreich, %d fehlgeschlagen",
+                success_count,
+                error_count,
+            )
             return 0
-        case Err(error):
-            logging.error("Einreichung fehlgeschlagen: %s", error)
+        if error_count > 0:
+            logging.error("Alle PRs fehlgeschlagen.")
             return 1
+        return 0
 
 
 if __name__ == "__main__":

--- a/examples/.dependapy.yml
+++ b/examples/.dependapy.yml
@@ -1,0 +1,48 @@
+# dependapy Policy Configuration
+# Place this file in your project root as .dependapy.yml or .dependapy.yaml
+# Docs: https://dependapy.readthedocs.io/en/latest/guide/policy/
+version: 1
+
+# Packages to ignore entirely — no PRs will be created
+ignore:
+  - name: "legacy-internal-*"
+    reason: "Maintained internally, updated manually"
+  - name: "setuptools"
+    reason: "Pinned for compatibility"
+
+# Restrict which update types are allowed per package
+allow:
+  - name: "boto*"
+    update-types: ["minor", "patch"]
+  - name: "django"
+    update-types: ["patch"]
+  - name: "*"
+    update-types: ["minor", "patch", "major"]
+
+# Labels applied to every PR dependapy creates
+labels:
+  - dependencies
+  - automated
+
+# Reviewers added to every PR (users and teams)
+reviewers:
+  - "@your-team/platform"
+
+# Assignees added to every PR
+assignees:
+  - "@your-username"
+
+# Commit message formatting
+commit-message:
+  prefix: "build(deps)"
+  include-scope: true  # Adds package name as scope, e.g. build(deps/requests):
+
+# Auto-merge PRs when all status checks pass (requires branch protection)
+auto-merge: true
+
+# Group related packages into a single PR
+groups:
+  - name: "aws"
+    patterns: ["boto*", "aws-*", "s3transfer"]
+  - name: "testing"
+    patterns: ["pytest*", "coverage", "responses"]

--- a/examples/example_dependapy.yml
+++ b/examples/example_dependapy.yml
@@ -2,8 +2,8 @@ name: Dependapy
 
 on:
   schedule:
-    # Run every Sunday at 02:00 UTC
-    - cron: '0 2 * * 0'
+    # Run daily at 06:00 UTC
+    - cron: '0 6 * * *'
   workflow_dispatch:  # Allow manual triggering
 
 jobs:
@@ -25,16 +25,52 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-          cache: "pip"
-          
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
         run: uv sync --group dev
 
+      - name: Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Run dependapy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPENDAPY_VCS_PROVIDER: github
+          DEPENDAPY_VCS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPENDAPY_MAX_PRS: "10"
+          DEPENDAPY_NOTIFY_CODEOWNERS: "true"
         run: |
-          uv run dependapy .
+          uv run dependapy . --max-prs 10
+
+  # ── Offline / Air-Gapped Runner ───────────────────────────────────
+  # For runners without internet access, use --offline.
+  # dependapy reads versions from uv.lock or requirements.txt instead
+  # of querying PyPI. Combine with a .dependapy.yml policy file for
+  # ignore rules, labels, reviewers, and commit-message formatting.
+  #
+  # update-dependencies-offline:
+  #   name: Update Dependencies (Offline)
+  #   runs-on: self-hosted  # air-gapped runner
+  #   permissions:
+  #     contents: write
+  #     pull-requests: write
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Configure Git identity
+  #       run: |
+  #         git config user.name "github-actions[bot]"
+  #         git config user.email "github-actions[bot]@users.noreply.github.com"
+  #     - name: Run dependapy (offline)
+  #       env:
+  #         DEPENDAPY_VCS_PROVIDER: github
+  #         DEPENDAPY_VCS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         DEPENDAPY_OFFLINE: "true"
+  #       run: |
+  #         uv run dependapy . --offline --max-prs 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
 github = [
     "PyGithub>=2.6.1",
 ]
+policy = [
+    "PyYAML>=6.0",
+]
 [dependency-groups]
 dev = [
     "pytest>=7.4.0",

--- a/tests/application/test_config.py
+++ b/tests/application/test_config.py
@@ -16,6 +16,8 @@ class TestAppConfigDefaults:
         assert cfg.vcs_base_branch == "main"
         assert cfg.branch_prefix == "dependapy/"
         assert cfg.log_level == "INFO"
+        assert cfg.max_prs == 10
+        assert cfg.notify_codeowners is True
 
     def test_frozen(self) -> None:
         cfg = AppConfig()
@@ -47,6 +49,24 @@ class TestAppConfigFromEnv:
         monkeypatch.setenv("DEPENDAPY_VCS_TOKEN", "")
         cfg = AppConfig.from_env()
         assert cfg.vcs_token is None
+
+    def test_max_prs_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEPENDAPY_MAX_PRS", "5")
+        cfg = AppConfig.from_env()
+        assert cfg.max_prs == 5
+
+    def test_notify_codeowners_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEPENDAPY_NOTIFY_CODEOWNERS", "false")
+        cfg = AppConfig.from_env()
+        assert cfg.notify_codeowners is False
+
+    def test_notify_codeowners_true_by_default(self) -> None:
+        cfg = AppConfig.from_env()
+        assert cfg.notify_codeowners is True
+
+    def test_max_prs_override(self) -> None:
+        cfg = AppConfig.from_env(max_prs=3)
+        assert cfg.max_prs == 3
 
 
 class TestVCSProvider:

--- a/tests/application/test_use_cases.py
+++ b/tests/application/test_use_cases.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from dependapy.application.dtos import AnalysisResult
 from dependapy.application.use_cases import AnalyzeDependencies, ApplyUpdates, SubmitChanges
 from dependapy.domain.models import Project
 from dependapy.domain.value_objects import ConstraintOperator, VersionConstraint
@@ -313,3 +314,155 @@ class TestSubmitChanges:
         assert "dependapy/test-branch" in vcs.branches_created
         assert len(vcs.commits_made) == 1
         assert "dependapy/test-branch" in vcs.pushes_made
+
+    def test_reviewers_are_passed_to_pr_request(self, tmp_path: Path) -> None:
+        vcs = FakeVCSPort()
+        use_case = SubmitChanges(vcs=vcs)
+
+        use_case.execute(
+            repo_path=tmp_path,
+            updated_files=[tmp_path / "pyproject.toml"],
+            reviewers=["@alice", "@team/backend"],
+        )
+
+        assert len(vcs.prs_created) == 1
+        assert vcs.prs_created[0].reviewers == ["@alice", "@team/backend"]
+
+    def test_reviewers_default_is_none(self, tmp_path: Path) -> None:
+        vcs = FakeVCSPort()
+        use_case = SubmitChanges(vcs=vcs)
+
+        use_case.execute(
+            repo_path=tmp_path,
+            updated_files=[tmp_path / "pyproject.toml"],
+        )
+
+        assert len(vcs.prs_created) == 1
+        assert vcs.prs_created[0].reviewers is None
+
+
+class TestSubmitChangesPerProject:
+    """Tests für SubmitChanges.execute_per_project()."""
+
+    @staticmethod
+    def _make_analysis(name: str, outdated: int, path: Path | None = None) -> AnalysisResult:
+        deps = [make_dep(f"pkg-{i}", "1.0.0", latest="2.0.0") for i in range(max(outdated, 1))]
+        proj = Project(
+            name=name,
+            path=path or Path(f"/fake/{name}/pyproject.toml"),
+            dependencies=deps,
+        )
+        return AnalysisResult(project=proj, outdated_count=outdated, total_count=max(outdated, 1))
+
+    def test_creates_pr_per_project(self, tmp_path: Path) -> None:
+        vcs = FakeVCSPort()
+        use_case = SubmitChanges(vcs=vcs)
+
+        path_a = tmp_path / "a" / "pyproject.toml"
+        path_b = tmp_path / "b" / "pyproject.toml"
+
+        analysis_a = self._make_analysis("project-a", 2, path_a)
+        analysis_b = self._make_analysis("project-b", 1, path_b)
+
+        results = use_case.execute_per_project(
+            repo_path=tmp_path,
+            analysis_results=[analysis_a, analysis_b],
+            updated_files_by_project={
+                path_a: [path_a],
+                path_b: [path_b],
+            },
+        )
+
+        assert len(results) == 2
+        assert all(r.is_ok() for r in results)
+        assert len(vcs.prs_created) == 2
+
+    def test_respects_max_prs_limit(self, tmp_path: Path) -> None:
+        vcs = FakeVCSPort()
+        use_case = SubmitChanges(vcs=vcs)
+
+        analyses = []
+        files_map: dict[Path, list[Path]] = {}
+        for i in range(5):
+            path = tmp_path / f"proj-{i}" / "pyproject.toml"
+            analysis = self._make_analysis(f"project-{i}", 1, path)
+            analyses.append(analysis)
+            files_map[path] = [path]
+
+        results = use_case.execute_per_project(
+            repo_path=tmp_path,
+            analysis_results=analyses,
+            updated_files_by_project=files_map,
+            max_prs=2,
+        )
+
+        assert len(results) == 2
+        assert len(vcs.prs_created) == 2
+
+    def test_skips_projects_without_outdated_deps(self, tmp_path: Path) -> None:
+        vcs = FakeVCSPort()
+        use_case = SubmitChanges(vcs=vcs)
+
+        path = tmp_path / "a" / "pyproject.toml"
+        analysis = self._make_analysis("project-a", 0, path)
+
+        results = use_case.execute_per_project(
+            repo_path=tmp_path,
+            analysis_results=[analysis],
+            updated_files_by_project={path: [path]},
+        )
+
+        assert len(results) == 0
+        assert len(vcs.prs_created) == 0
+
+    def test_assigns_reviewers_from_codeowners(self, tmp_path: Path) -> None:
+        vcs = FakeVCSPort()
+        use_case = SubmitChanges(vcs=vcs)
+
+        path = tmp_path / "dependapy" / "pyproject.toml"
+        analysis = self._make_analysis("dependapy", 2, path)
+        rel_path = str(path.relative_to(tmp_path))
+
+        results = use_case.execute_per_project(
+            repo_path=tmp_path,
+            analysis_results=[analysis],
+            updated_files_by_project={path: [path]},
+            reviewers_by_file={rel_path: ["@alice", "@team/core"]},
+        )
+
+        assert len(results) == 1
+        assert results[0].is_ok()
+        assert vcs.prs_created[0].reviewers == ["@alice", "@team/core"]
+
+    def test_branch_name_uses_project_name(self, tmp_path: Path) -> None:
+        vcs = FakeVCSPort()
+        use_case = SubmitChanges(vcs=vcs)
+
+        path = tmp_path / "my-app" / "pyproject.toml"
+        analysis = self._make_analysis("my-app", 1, path)
+
+        use_case.execute_per_project(
+            repo_path=tmp_path,
+            analysis_results=[analysis],
+            updated_files_by_project={path: [path]},
+            branch_prefix="dependapy/",
+        )
+
+        assert "dependapy/update-my-app" in vcs.branches_created
+
+    def test_continues_after_failed_pr(self, tmp_path: Path) -> None:
+        """Wenn ein PR fehlschlägt, werden die restlichen trotzdem erstellt."""
+        vcs = FakeVCSPort(fail_on_pr=True)
+        use_case = SubmitChanges(vcs=vcs)
+
+        path = tmp_path / "a" / "pyproject.toml"
+        analysis = self._make_analysis("project-a", 1, path)
+
+        results = use_case.execute_per_project(
+            repo_path=tmp_path,
+            analysis_results=[analysis],
+            updated_files_by_project={path: [path]},
+        )
+
+        assert len(results) == 1
+        assert results[0].is_err()

--- a/tests/infrastructure/test_codeowners.py
+++ b/tests/infrastructure/test_codeowners.py
@@ -1,0 +1,166 @@
+"""Tests für den CODEOWNERS Parser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dependapy.infrastructure.adapters.codeowners import (
+    CodeownersEntry,
+    find_owners_for_file,
+    find_owners_for_files,
+    parse_codeowners,
+)
+
+
+class TestCodeownersEntry:
+    """Tests für CodeownersEntry.matches()."""
+
+    def test_exact_file_match(self) -> None:
+        entry = CodeownersEntry("pyproject.toml", ["@alice"])
+        assert entry.matches("pyproject.toml")
+
+    def test_directory_pattern_matches_file_inside(self) -> None:
+        entry = CodeownersEntry("src/", ["@team/backend"])
+        assert entry.matches("src/main.py")
+        assert entry.matches("src/deep/nested/file.py")
+
+    def test_directory_pattern_does_not_match_outside(self) -> None:
+        entry = CodeownersEntry("src/", ["@team/backend"])
+        assert not entry.matches("tests/test_main.py")
+
+    def test_glob_pattern_matches(self) -> None:
+        entry = CodeownersEntry("*.toml", ["@ops"])
+        assert entry.matches("pyproject.toml")
+        assert entry.matches("config.toml")
+
+    def test_glob_pattern_does_not_match_other_extension(self) -> None:
+        entry = CodeownersEntry("*.toml", ["@ops"])
+        assert not entry.matches("README.md")
+
+    def test_path_prefix_match_without_trailing_slash(self) -> None:
+        entry = CodeownersEntry("dependapy", ["@team/core"])
+        assert entry.matches("dependapy/main.py")
+        assert entry.matches("dependapy/domain/models.py")
+
+    def test_leading_slash_is_stripped(self) -> None:
+        entry = CodeownersEntry("/src/", ["@alice"])
+        assert entry.matches("src/main.py")
+
+    def test_no_match_for_unrelated_path(self) -> None:
+        entry = CodeownersEntry("docs/", ["@docs-team"])
+        assert not entry.matches("src/main.py")
+
+
+class TestParseCodeowners:
+    """Tests für parse_codeowners()."""
+
+    def test_parses_standard_codeowners_file(self, tmp_path: Path) -> None:
+        codeowners_dir = tmp_path / ".github"
+        codeowners_dir.mkdir()
+        codeowners_file = codeowners_dir / "CODEOWNERS"
+        codeowners_file.write_text(
+            "# Global owners\n* @global-owner\n*.toml @ops-team\ndependapy/ @team/core @alice\n"
+        )
+
+        entries = parse_codeowners(tmp_path)
+        assert len(entries) == 3
+        assert entries[0].pattern == "*"
+        assert entries[0].owners == ["@global-owner"]
+        assert entries[1].pattern == "*.toml"
+        assert entries[1].owners == ["@ops-team"]
+        assert entries[2].pattern == "dependapy/"
+        assert entries[2].owners == ["@team/core", "@alice"]
+
+    def test_returns_empty_when_no_file(self, tmp_path: Path) -> None:
+        entries = parse_codeowners(tmp_path)
+        assert entries == []
+
+    def test_ignores_comment_lines(self, tmp_path: Path) -> None:
+        codeowners = tmp_path / "CODEOWNERS"
+        codeowners.write_text("# Only comments\n# Another comment\n")
+        entries = parse_codeowners(tmp_path)
+        assert entries == []
+
+    def test_ignores_empty_lines(self, tmp_path: Path) -> None:
+        codeowners = tmp_path / "CODEOWNERS"
+        codeowners.write_text("\n\n* @owner\n\n")
+        entries = parse_codeowners(tmp_path)
+        assert len(entries) == 1
+
+    def test_finds_codeowners_in_root(self, tmp_path: Path) -> None:
+        codeowners = tmp_path / "CODEOWNERS"
+        codeowners.write_text("* @root-owner\n")
+        entries = parse_codeowners(tmp_path)
+        assert len(entries) == 1
+
+    def test_finds_codeowners_in_docs(self, tmp_path: Path) -> None:
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        codeowners = docs_dir / "CODEOWNERS"
+        codeowners.write_text("docs/ @docs-team\n")
+        entries = parse_codeowners(tmp_path)
+        assert len(entries) == 1
+
+    def test_prefers_github_directory(self, tmp_path: Path) -> None:
+        """GitHub CODEOWNERS has priority over root CODEOWNERS."""
+        # Create both .github/CODEOWNERS and root CODEOWNERS
+        github_dir = tmp_path / ".github"
+        github_dir.mkdir()
+        (github_dir / "CODEOWNERS").write_text("* @github-owner\n")
+        (tmp_path / "CODEOWNERS").write_text("* @root-owner\n")
+
+        entries = parse_codeowners(tmp_path)
+        assert len(entries) == 1
+        assert entries[0].owners == ["@github-owner"]
+
+
+class TestFindOwnersForFile:
+    """Tests für find_owners_for_file()."""
+
+    def test_last_matching_rule_wins(self) -> None:
+        entries = [
+            CodeownersEntry("*", ["@global"]),
+            CodeownersEntry("*.toml", ["@ops"]),
+        ]
+        owners = find_owners_for_file("pyproject.toml", entries)
+        assert owners == ["@ops"]
+
+    def test_returns_empty_when_no_match(self) -> None:
+        entries = [CodeownersEntry("src/", ["@team"])]
+        owners = find_owners_for_file("README.md", entries)
+        assert owners == []
+
+    def test_specific_rule_overrides_global(self) -> None:
+        entries = [
+            CodeownersEntry("*", ["@global"]),
+            CodeownersEntry("dependapy/", ["@core-team"]),
+        ]
+        owners = find_owners_for_file("dependapy/main.py", entries)
+        assert owners == ["@core-team"]
+
+
+class TestFindOwnersForFiles:
+    """Tests für find_owners_for_files()."""
+
+    def test_collects_unique_owners_across_files(self) -> None:
+        entries = [
+            CodeownersEntry("*.toml", ["@ops"]),
+            CodeownersEntry("dependapy/", ["@core", "@alice"]),
+        ]
+        owners = find_owners_for_files(
+            ["pyproject.toml", "dependapy/main.py"],
+            entries,
+        )
+        assert owners == ["@alice", "@core", "@ops"]
+
+    def test_returns_empty_for_no_matches(self) -> None:
+        entries = [CodeownersEntry("src/", ["@team"])]
+        owners = find_owners_for_files(["README.md", "LICENSE"], entries)
+        assert owners == []
+
+    def test_deduplicates_owners(self) -> None:
+        entries = [
+            CodeownersEntry("*", ["@shared-owner"]),
+        ]
+        owners = find_owners_for_files(["file1.py", "file2.py"], entries)
+        assert owners == ["@shared-owner"]

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1,0 +1,150 @@
+"""Tests für den Offline-Betrieb — OfflineRegistryAdapter und Config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from dependapy.domain.result import Err, Ok
+from dependapy.infrastructure.adapters.offline_registry import OfflineRegistryAdapter
+
+
+class TestOfflineRegistryFromUvLock:
+    def test_load_from_uv_lock(self, tmp_path: Path) -> None:
+        uv_lock = dedent("""\
+            version = 1
+            requires-python = ">=3.12"
+
+            [[package]]
+            name = "requests"
+            version = "2.32.3"
+            source = { registry = "https://pypi.org/simple" }
+
+            [[package]]
+            name = "flask"
+            version = "3.1.0"
+            source = { registry = "https://pypi.org/simple" }
+        """)
+        (tmp_path / "uv.lock").write_text(uv_lock)
+
+        adapter = OfflineRegistryAdapter(tmp_path)
+        result = adapter.get_latest_version("requests")
+        assert isinstance(result, Ok)
+        assert str(result.unwrap()) == "2.32.3"
+
+        result2 = adapter.get_latest_version("flask")
+        assert isinstance(result2, Ok)
+        assert str(result2.unwrap()) == "3.1.0"
+
+    def test_package_not_found(self, tmp_path: Path) -> None:
+        (tmp_path / "uv.lock").write_text('version = 1\nrequires-python = ">=3.12"\n')
+        adapter = OfflineRegistryAdapter(tmp_path)
+        result = adapter.get_latest_version("nonexistent")
+        assert isinstance(result, Err)
+
+    def test_batch_lookup(self, tmp_path: Path) -> None:
+        uv_lock = dedent("""\
+            version = 1
+
+            [[package]]
+            name = "requests"
+            version = "2.32.3"
+
+            [[package]]
+            name = "flask"
+            version = "3.1.0"
+        """)
+        (tmp_path / "uv.lock").write_text(uv_lock)
+
+        adapter = OfflineRegistryAdapter(tmp_path)
+        results = adapter.get_latest_versions_batch(["requests", "flask", "unknown"])
+        assert isinstance(results["requests"], Ok)
+        assert isinstance(results["flask"], Ok)
+        assert isinstance(results["unknown"], Err)
+
+    def test_normalized_names(self, tmp_path: Path) -> None:
+        """PEP 503 name normalization: dashes, underscores, dots → interchangeable."""
+        uv_lock = dedent("""\
+            version = 1
+
+            [[package]]
+            name = "my-cool-package"
+            version = "1.0.0"
+        """)
+        (tmp_path / "uv.lock").write_text(uv_lock)
+
+        adapter = OfflineRegistryAdapter(tmp_path)
+        assert isinstance(adapter.get_latest_version("my-cool-package"), Ok)
+        assert isinstance(adapter.get_latest_version("my_cool_package"), Ok)
+        assert isinstance(adapter.get_latest_version("my.cool.package"), Ok)
+
+
+class TestOfflineRegistryFromRequirements:
+    def test_load_from_requirements_txt(self, tmp_path: Path) -> None:
+        reqs = dedent("""\
+            requests==2.32.3
+            flask==3.1.0
+            # A comment
+            -r other.txt
+            some-package>=1.0  # Not pinned, ignored
+        """)
+        (tmp_path / "requirements.txt").write_text(reqs)
+
+        adapter = OfflineRegistryAdapter(tmp_path)
+        result = adapter.get_latest_version("requests")
+        assert isinstance(result, Ok)
+        assert str(result.unwrap()) == "2.32.3"
+
+        # Non-pinned packages should not be loaded
+        result2 = adapter.get_latest_version("some-package")
+        assert isinstance(result2, Err)
+
+    def test_uv_lock_has_priority(self, tmp_path: Path) -> None:
+        """uv.lock wird vor requirements.txt geladen."""
+        (tmp_path / "uv.lock").write_text(
+            'version = 1\n\n[[package]]\nname = "requests"\nversion = "2.99.0"\n'
+        )
+        (tmp_path / "requirements.txt").write_text("requests==1.0.0\n")
+
+        adapter = OfflineRegistryAdapter(tmp_path)
+        result = adapter.get_latest_version("requests")
+        assert isinstance(result, Ok)
+        assert str(result.unwrap()) == "2.99.0"
+
+
+class TestOfflineRegistryNoFiles:
+    def test_empty_project(self, tmp_path: Path) -> None:
+        adapter = OfflineRegistryAdapter(tmp_path)
+        result = adapter.get_latest_version("requests")
+        assert isinstance(result, Err)
+
+
+class TestOfflineConfig:
+    def test_offline_config_env(self) -> None:
+        import os
+
+        from dependapy.application.config import AppConfig
+
+        old_val = os.environ.get("DEPENDAPY_OFFLINE")
+        try:
+            os.environ["DEPENDAPY_OFFLINE"] = "true"
+            config = AppConfig.from_env()
+            assert config.offline is True
+        finally:
+            if old_val is None:
+                os.environ.pop("DEPENDAPY_OFFLINE", None)
+            else:
+                os.environ["DEPENDAPY_OFFLINE"] = old_val
+
+    def test_offline_default_false(self) -> None:
+        import os
+
+        from dependapy.application.config import AppConfig
+
+        old_val = os.environ.pop("DEPENDAPY_OFFLINE", None)
+        try:
+            config = AppConfig.from_env()
+            assert config.offline is False
+        finally:
+            if old_val is not None:
+                os.environ["DEPENDAPY_OFFLINE"] = old_val

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,578 @@
+"""Tests für den Policy Domain Model und Policy Loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from dependapy.application.use_cases import AnalyzeDependencies, SubmitChanges
+from dependapy.domain.policy import (
+    AllowRule,
+    CommitMessage,
+    DependencyGroup,
+    IgnoreRule,
+    Policy,
+)
+from dependapy.domain.result import Ok
+from dependapy.infrastructure.adapters.policy_loader import load_policy
+from tests.factories import make_dep, make_project
+from tests.fakes import (
+    FakePackageRegistry,
+    FakeProjectRepository,
+    FakePythonVersionRegistry,
+    FakeVCSPort,
+)
+
+# === Policy Domain Model Tests ===
+
+
+class TestIgnoreRule:
+    def test_exact_match(self) -> None:
+        rule = IgnoreRule(name="requests")
+        assert rule.matches("requests")
+        assert not rule.matches("flask")
+
+    def test_glob_match(self) -> None:
+        rule = IgnoreRule(name="boto*")
+        assert rule.matches("boto3")
+        assert rule.matches("botocore")
+        assert not rule.matches("flask")
+
+    def test_case_insensitive(self) -> None:
+        rule = IgnoreRule(name="Requests")
+        assert rule.matches("requests")
+        assert rule.matches("REQUESTS")
+
+
+class TestAllowRule:
+    def test_exact_match(self) -> None:
+        rule = AllowRule(name="requests", update_types=frozenset({"minor", "patch"}))
+        assert rule.matches("requests")
+        assert not rule.matches("flask")
+
+    def test_glob_match(self) -> None:
+        rule = AllowRule(name="*", update_types=frozenset({"patch"}))
+        assert rule.matches("anything")
+
+    def test_default_all_types(self) -> None:
+        rule = AllowRule(name="*")
+        assert rule.update_types == frozenset({"major", "minor", "patch"})
+
+
+class TestDependencyGroup:
+    def test_matches_patterns(self) -> None:
+        group = DependencyGroup(name="aws", patterns=("boto*", "aws*"))
+        assert group.matches("boto3")
+        assert group.matches("aws-cdk")
+        assert not group.matches("requests")
+
+    def test_empty_patterns(self) -> None:
+        group = DependencyGroup(name="empty")
+        assert not group.matches("anything")
+
+
+class TestPolicy:
+    def test_is_ignored(self) -> None:
+        policy = Policy(ignore=(IgnoreRule(name="legacy-pkg"), IgnoreRule(name="boto*")))
+        assert policy.is_ignored("legacy-pkg")
+        assert policy.is_ignored("boto3")
+        assert not policy.is_ignored("requests")
+
+    def test_allowed_update_types_default(self) -> None:
+        policy = Policy()
+        assert policy.allowed_update_types("anything") == frozenset({"major", "minor", "patch"})
+
+    def test_allowed_update_types_restricted(self) -> None:
+        policy = Policy(
+            allow=(
+                AllowRule(name="requests", update_types=frozenset({"major", "minor", "patch"})),
+                AllowRule(name="*", update_types=frozenset({"minor", "patch"})),
+            )
+        )
+        # requests has its own specific rule
+        assert policy.allowed_update_types("requests") == frozenset({"major", "minor", "patch"})
+        # Everything else matches the wildcard
+        assert policy.allowed_update_types("flask") == frozenset({"minor", "patch"})
+
+    def test_find_group(self) -> None:
+        policy = Policy(
+            groups=(
+                DependencyGroup(name="aws", patterns=("boto*",)),
+                DependencyGroup(name="web", patterns=("flask*", "django*")),
+            )
+        )
+        assert policy.find_group("boto3") is not None
+        assert policy.find_group("boto3").name == "aws"  # type: ignore[union-attr]
+        assert policy.find_group("flask") is not None
+        assert policy.find_group("unknown") is None
+
+    def test_format_commit_message_with_scope(self) -> None:
+        policy = Policy(commit_message=CommitMessage(prefix="fix(deps)", include_scope=True))
+        msg = policy.format_commit_message("api", "update requests")
+        assert msg == "fix(deps)(api): update requests"
+
+    def test_format_commit_message_without_scope(self) -> None:
+        policy = Policy(commit_message=CommitMessage(prefix="chore", include_scope=False))
+        msg = policy.format_commit_message("api", "update requests")
+        assert msg == "chore: update requests"
+
+
+# === Policy Loader Tests ===
+
+
+class TestPolicyLoader:
+    def test_load_not_found(self, tmp_path: Path) -> None:
+        result = load_policy(tmp_path)
+        assert result.is_err()
+
+    def test_load_valid_policy(self, tmp_path: Path) -> None:
+        yaml_content = dedent("""\
+            version: 1
+            ignore:
+              - name: "legacy-pkg"
+                reason: "deprecated"
+              - "old-package"
+            allow:
+              - name: "*"
+                update-types: ["minor", "patch"]
+            labels:
+              - dependencies
+              - automated
+            reviewers:
+              - "@user1"
+              - "@org/team"
+            assignees:
+              - "@user2"
+            commit-message:
+              prefix: "fix(deps)"
+              include-scope: false
+            groups:
+              - name: "aws"
+                patterns: ["boto*", "aws*"]
+        """)
+        (tmp_path / ".dependapy.yml").write_text(yaml_content)
+
+        result = load_policy(tmp_path)
+        assert result.is_ok()
+        policy = result.unwrap()
+
+        assert policy.version == 1
+        assert len(policy.ignore) == 2
+        assert policy.ignore[0].name == "legacy-pkg"
+        assert policy.ignore[0].reason == "deprecated"
+        assert policy.ignore[1].name == "old-package"
+        assert len(policy.allow) == 1
+        assert policy.allow[0].update_types == frozenset({"minor", "patch"})
+        assert policy.labels == ("dependencies", "automated")
+        assert policy.reviewers == ("@user1", "@org/team")
+        assert policy.assignees == ("@user2",)
+        assert policy.commit_message.prefix == "fix(deps)"
+        assert policy.commit_message.include_scope is False
+        assert len(policy.groups) == 1
+        assert policy.groups[0].name == "aws"
+
+    def test_load_yaml_variant(self, tmp_path: Path) -> None:
+        (tmp_path / ".dependapy.yaml").write_text("version: 1\n")
+        result = load_policy(tmp_path)
+        assert result.is_ok()
+
+    def test_load_invalid_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / ".dependapy.yml").write_text(": invalid: yaml: [")
+        result = load_policy(tmp_path)
+        assert result.is_err()
+
+    def test_load_non_dict_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / ".dependapy.yml").write_text("- just a list\n")
+        result = load_policy(tmp_path)
+        assert result.is_err()
+
+    def test_load_invalid_version(self, tmp_path: Path) -> None:
+        (tmp_path / ".dependapy.yml").write_text("version: 99\n")
+        result = load_policy(tmp_path)
+        assert result.is_err()
+
+    def test_load_minimal_policy(self, tmp_path: Path) -> None:
+        (tmp_path / ".dependapy.yml").write_text("version: 1\n")
+        result = load_policy(tmp_path)
+        assert result.is_ok()
+        policy = result.unwrap()
+        assert policy.ignore == ()
+        assert policy.allow == ()
+        assert policy.labels == ()
+
+
+# === Policy Integration in Use Cases ===
+
+
+class TestPolicyInAnalyze:
+    def test_ignored_packages_excluded(self) -> None:
+        registry = FakePackageRegistry(
+            versions={"requests": "3.0.0", "legacy": "2.0.0"},
+        )
+        proj_repo = FakeProjectRepository()
+        python_reg = FakePythonVersionRegistry()
+
+        proj = make_project(
+            make_dep("requests", "2.31.0", latest="3.0.0"),
+            make_dep("legacy", "1.0.0", latest="2.0.0"),
+            path=Path("/tmp/test"),
+        )
+        proj_repo.add_project(proj)
+
+        uc = AnalyzeDependencies(
+            registry=registry,
+            project_repo=proj_repo,
+            python_registry=python_reg,
+        )
+
+        result_no_policy = uc.execute(Path("/tmp/test"))
+        assert isinstance(result_no_policy, Ok)
+        assert result_no_policy.unwrap()[0].outdated_count == 2
+
+    def test_policy_filters_ignored(self) -> None:
+        registry = FakePackageRegistry(
+            versions={"requests": "3.0.0", "legacy": "2.0.0"},
+        )
+        proj_repo = FakeProjectRepository()
+        python_reg = FakePythonVersionRegistry()
+
+        proj = make_project(
+            make_dep("requests", "2.31.0", latest="3.0.0"),
+            make_dep("legacy", "1.0.0", latest="2.0.0"),
+            path=Path("/tmp/test"),
+        )
+        proj_repo.add_project(proj)
+
+        uc = AnalyzeDependencies(
+            registry=registry,
+            project_repo=proj_repo,
+            python_registry=python_reg,
+        )
+        policy = Policy(ignore=(IgnoreRule(name="legacy"),))
+        result = uc.execute(Path("/tmp/test"), policy=policy)
+        assert isinstance(result, Ok)
+        assert result.unwrap()[0].outdated_count == 1
+
+    def test_policy_filters_update_types(self) -> None:
+        registry = FakePackageRegistry(
+            versions={"requests": "3.0.0"},
+        )
+        proj_repo = FakeProjectRepository()
+        python_reg = FakePythonVersionRegistry()
+
+        proj = make_project(
+            make_dep("requests", "2.31.0", latest="3.0.0"),
+            path=Path("/tmp/test"),
+        )
+        proj_repo.add_project(proj)
+
+        uc = AnalyzeDependencies(
+            registry=registry,
+            project_repo=proj_repo,
+            python_registry=python_reg,
+        )
+        policy = Policy(
+            allow=(
+                AllowRule(
+                    name="*",
+                    update_types=frozenset({"minor", "patch"}),
+                ),
+            ),
+        )
+        result = uc.execute(Path("/tmp/test"), policy=policy)
+        assert isinstance(result, Ok)
+        assert result.unwrap()[0].outdated_count == 0
+
+
+class TestPolicyInSubmit:
+    def test_policy_labels_in_pr(self) -> None:
+        vcs = FakeVCSPort()
+        uc = SubmitChanges(vcs=vcs)
+        policy = Policy(labels=("dependencies", "automated"))
+
+        result = uc.execute(
+            Path("/tmp/repo"),
+            [Path("/tmp/repo/pyproject.toml")],
+            policy=policy,
+        )
+        assert isinstance(result, Ok)
+        assert vcs.prs_created[0].labels == [
+            "dependencies",
+            "automated",
+        ]
+
+    def test_policy_reviewers_merged_with_codeowners(self) -> None:
+        assert SubmitChanges._merge_reviewers(
+            ["@alice"],
+            Policy(reviewers=("@bob", "@org/team")),
+        ) == ["@alice", "@bob", "@org/team"]
+
+    def test_policy_commit_message(self) -> None:
+        vcs = FakeVCSPort()
+        uc = SubmitChanges(vcs=vcs)
+        policy = Policy(
+            commit_message=CommitMessage(
+                prefix="build(deps)",
+                include_scope=True,
+            ),
+        )
+
+        result = uc.execute(
+            Path("/tmp/repo"),
+            [Path("/tmp/repo/pyproject.toml")],
+            policy=policy,
+        )
+        assert isinstance(result, Ok)
+        assert "build(deps)" in vcs.commits_made[0]
+
+
+# === Auto-Merge Tests ===
+
+
+class TestAutoMerge:
+    def test_auto_merge_in_pr_request(self) -> None:
+        vcs = FakeVCSPort()
+        uc = SubmitChanges(vcs=vcs)
+        policy = Policy(auto_merge=True)
+
+        result = uc.execute(
+            Path("/tmp/repo"),
+            [Path("/tmp/repo/pyproject.toml")],
+            policy=policy,
+        )
+        assert isinstance(result, Ok)
+        assert vcs.prs_created[0].auto_merge is True
+
+    def test_no_auto_merge_by_default(self) -> None:
+        vcs = FakeVCSPort()
+        uc = SubmitChanges(vcs=vcs)
+
+        result = uc.execute(
+            Path("/tmp/repo"),
+            [Path("/tmp/repo/pyproject.toml")],
+        )
+        assert isinstance(result, Ok)
+        assert vcs.prs_created[0].auto_merge is False
+
+    def test_auto_merge_parsed_from_policy(self, tmp_path: Path) -> None:
+        yaml_content = dedent("""\
+            version: 1
+            auto-merge: true
+        """)
+        (tmp_path / ".dependapy.yml").write_text(yaml_content)
+        result = load_policy(tmp_path)
+        assert result.is_ok()
+        assert result.unwrap().auto_merge is True
+
+
+# === Dependency Grouping Tests ===
+
+
+class TestGroupedPRs:
+    def _make_analysis(
+        self,
+        name: str,
+        *dep_names: str,
+        path: Path | None = None,
+    ) -> tuple:
+        """Erzeugt ein AnalysisResult + Dateien-Mapping."""
+        from dependapy.application.dtos import AnalysisResult
+
+        deps = [make_dep(n, "1.0.0", latest="2.0.0") for n in dep_names]
+        proj_path = path or Path(f"/tmp/{name}")
+        proj = make_project(*deps, name=name, path=proj_path)
+        proj.mark_analyzed()
+        analysis = AnalysisResult(
+            project=proj,
+            outdated_count=len(deps),
+            total_count=len(deps),
+        )
+        files = [proj_path / "pyproject.toml"]
+        return analysis, {proj_path: files}
+
+    def test_grouped_deps_single_pr(self) -> None:
+        """Dependencies in der gleichen Gruppe → ein PR."""
+        vcs = FakeVCSPort()
+        uc = SubmitChanges(vcs=vcs)
+
+        policy = Policy(
+            groups=(
+                DependencyGroup(
+                    name="aws",
+                    patterns=("boto*", "s3transfer"),
+                ),
+            ),
+        )
+
+        a1, f1 = self._make_analysis(
+            "svc-a",
+            "boto3",
+            path=Path("/tmp/svc-a"),
+        )
+        a2, f2 = self._make_analysis(
+            "svc-b",
+            "s3transfer",
+            path=Path("/tmp/svc-b"),
+        )
+
+        all_files = {**f1, **f2}
+        results = uc.execute_per_project(
+            repo_path=Path("/tmp"),
+            analysis_results=[a1, a2],
+            updated_files_by_project=all_files,
+            policy=policy,
+        )
+
+        # Nur 1 PR für die "aws"-Gruppe
+        ok_results = [r for r in results if isinstance(r, Ok)]
+        assert len(ok_results) == 1
+        assert "group-aws" in vcs.branches_created[0]
+
+    def test_ungrouped_get_individual_prs(self) -> None:
+        """Dependencies ohne Gruppen-Match → per-Projekt PRs."""
+        vcs = FakeVCSPort()
+        uc = SubmitChanges(vcs=vcs)
+
+        policy = Policy(
+            groups=(
+                DependencyGroup(
+                    name="aws",
+                    patterns=("boto*",),
+                ),
+            ),
+        )
+
+        a1, f1 = self._make_analysis(
+            "svc-a",
+            "flask",
+            path=Path("/tmp/svc-a"),
+        )
+        a2, f2 = self._make_analysis(
+            "svc-b",
+            "django",
+            path=Path("/tmp/svc-b"),
+        )
+
+        all_files = {**f1, **f2}
+        results = uc.execute_per_project(
+            repo_path=Path("/tmp"),
+            analysis_results=[a1, a2],
+            updated_files_by_project=all_files,
+            policy=policy,
+        )
+
+        ok_results = [r for r in results if isinstance(r, Ok)]
+        assert len(ok_results) == 2
+        branches = vcs.branches_created
+        assert any("update-svc-a" in b for b in branches)
+        assert any("update-svc-b" in b for b in branches)
+
+    def test_mixed_grouped_and_ungrouped(self) -> None:
+        """Gemischt: Gruppen-PR + individuelle PRs."""
+        vcs = FakeVCSPort()
+        uc = SubmitChanges(vcs=vcs)
+
+        policy = Policy(
+            groups=(
+                DependencyGroup(
+                    name="testing",
+                    patterns=("pytest*", "coverage"),
+                ),
+            ),
+        )
+
+        a1, f1 = self._make_analysis(
+            "lib-a",
+            "pytest",
+            path=Path("/tmp/lib-a"),
+        )
+        a2, f2 = self._make_analysis(
+            "lib-b",
+            "coverage",
+            path=Path("/tmp/lib-b"),
+        )
+        a3, f3 = self._make_analysis(
+            "app",
+            "flask",
+            path=Path("/tmp/app"),
+        )
+
+        all_files = {**f1, **f2, **f3}
+        results = uc.execute_per_project(
+            repo_path=Path("/tmp"),
+            analysis_results=[a1, a2, a3],
+            updated_files_by_project=all_files,
+            policy=policy,
+        )
+
+        ok_results = [r for r in results if isinstance(r, Ok)]
+        # 1 group PR (testing) + 1 individual PR (app/flask)
+        assert len(ok_results) == 2
+
+        branches = vcs.branches_created
+        assert any("group-testing" in b for b in branches)
+        assert any("update-app" in b for b in branches)
+
+    def test_grouping_respects_max_prs(self) -> None:
+        """max_prs begrenzt auch Gruppen-PRs."""
+        vcs = FakeVCSPort()
+        uc = SubmitChanges(vcs=vcs)
+
+        policy = Policy(
+            groups=(
+                DependencyGroup(name="g1", patterns=("pkg-a",)),
+                DependencyGroup(name="g2", patterns=("pkg-b",)),
+                DependencyGroup(name="g3", patterns=("pkg-c",)),
+            ),
+        )
+
+        analyses = []
+        all_files: dict[Path, list[Path]] = {}
+        for name in ("pkg-a", "pkg-b", "pkg-c"):
+            a, f = self._make_analysis(
+                name,
+                name,
+                path=Path(f"/tmp/{name}"),
+            )
+            analyses.append(a)
+            all_files.update(f)
+
+        results = uc.execute_per_project(
+            repo_path=Path("/tmp"),
+            analysis_results=analyses,
+            updated_files_by_project=all_files,
+            max_prs=2,
+            policy=policy,
+        )
+
+        ok_results = [r for r in results if isinstance(r, Ok)]
+        assert len(ok_results) == 2
+
+    def test_no_groups_falls_back_to_per_project(self) -> None:
+        """Ohne Gruppen-Definition → normales per-Projekt Verhalten."""
+        vcs = FakeVCSPort()
+        uc = SubmitChanges(vcs=vcs)
+
+        policy = Policy()  # Keine Gruppen
+
+        a1, f1 = self._make_analysis(
+            "svc-a",
+            "requests",
+            path=Path("/tmp/svc-a"),
+        )
+        a2, f2 = self._make_analysis(
+            "svc-b",
+            "flask",
+            path=Path("/tmp/svc-b"),
+        )
+
+        all_files = {**f1, **f2}
+        results = uc.execute_per_project(
+            repo_path=Path("/tmp"),
+            analysis_results=[a1, a2],
+            updated_files_by_project=all_files,
+            policy=policy,
+        )
+
+        ok_results = [r for r in results if isinstance(r, Ok)]
+        assert len(ok_results) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -260,6 +260,9 @@ dependencies = [
 github = [
     { name = "pygithub" },
 ]
+policy = [
+    { name = "pyyaml" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -285,9 +288,10 @@ dev = [
 requires-dist = [
     { name = "packaging", specifier = ">=25.0" },
     { name = "pygithub", marker = "extra == 'github'", specifier = ">=2.6.1" },
+    { name = "pyyaml", marker = "extra == 'policy'", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.32.4" },
 ]
-provides-extras = ["github"]
+provides-extras = ["github", "policy"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds four major features to bring dependapy closer to Dependabot feature parity:

### Policy Engine (`.dependapy.yml`)
- Domain model: `Policy`, `IgnoreRule`, `AllowRule`, `CommitMessage`, `DependencyGroup`
- YAML loader with validation (supports `.dependapy.yml`/`.yaml` variants)
- Ignore rules with glob patterns to skip packages
- Allow rules to restrict update types (major/minor/patch) per package
- Configurable labels, reviewers, assignees on PRs
- Commit message templating with prefix and scope
- PyYAML as optional dependency: `pip install dependapy[policy]`

### Offline / Air-Gapped Mode
- `OfflineRegistryAdapter` reads versions from `uv.lock` or `requirements.txt`
- `--offline` CLI flag + `DEPENDAPY_OFFLINE` env var
- Graceful fallback for isolated runners without internet access

### Dependency Grouping
- Policy groups combine related packages into a single PR (e.g. `boto*`, `aws-*` -> one "aws" PR)
- Ungrouped dependencies get individual per-project PRs
- Branch naming: `dependapy/group-{name}`

### Auto-Merge
- `auto-merge: true` in `.dependapy.yml` enables PR auto-merge
- GitHub adapter calls `pr.enable_automerge(merge_method="SQUASH")`
- Requires branch protection rules; fails gracefully with warning

### CODEOWNERS Integration
- Parser for `.github/CODEOWNERS` with glob/directory/exact matching
- Automatic reviewer assignment (`--no-codeowners` to disable)
- Merged with policy-defined reviewers (deduplicated)

## Quality
- **262 tests passing**, 93% coverage
- pyright: 0 errors, ruff: 0 errors
- All 3 import-linter architecture contracts kept (domain/app/infra/presentation)

## New Files
- `dependapy/domain/policy.py` — Policy domain model
- `dependapy/infrastructure/adapters/offline_registry.py` — Offline version source
- `dependapy/infrastructure/adapters/codeowners.py` — CODEOWNERS parser
- `examples/.dependapy.yml` — Example policy configuration
- `tests/test_policy.py` — 35 policy + grouping + auto-merge tests
- `tests/test_offline.py` — 12 offline mode tests
- `tests/infrastructure/test_codeowners.py` — CODEOWNERS tests
